### PR TITLE
Se implemeto Carta jugable y zona de jugador

### DIFF
--- a/Assets/Cards/CartaPrueba 1.asset
+++ b/Assets/Cards/CartaPrueba 1.asset
@@ -15,5 +15,5 @@ MonoBehaviour:
   nombreCarta: Test1
   icono: {fileID: 21300000, guid: c8f8fe1d78170e84eab15e7562604fdc, type: 3}
   descripcion: 
-  costoMana: 6
+  costoMana: 3
   prefabUnidad: {fileID: 0}

--- a/Assets/Cards/CartaPrueba 2.asset
+++ b/Assets/Cards/CartaPrueba 2.asset
@@ -15,5 +15,5 @@ MonoBehaviour:
   nombreCarta: Test1
   icono: {fileID: 21300000, guid: c8f8fe1d78170e84eab15e7562604fdc, type: 3}
   descripcion: 
-  costoMana: 7
+  costoMana: 4
   prefabUnidad: {fileID: 0}

--- a/Assets/Cards/CartaPrueba 3.asset
+++ b/Assets/Cards/CartaPrueba 3.asset
@@ -15,5 +15,5 @@ MonoBehaviour:
   nombreCarta: Test1
   icono: {fileID: 21300000, guid: c8f8fe1d78170e84eab15e7562604fdc, type: 3}
   descripcion: 
-  costoMana: 8
+  costoMana: 5
   prefabUnidad: {fileID: 0}

--- a/Assets/Cards/CartaPrueba.asset
+++ b/Assets/Cards/CartaPrueba.asset
@@ -15,5 +15,5 @@ MonoBehaviour:
   nombreCarta: Test1
   icono: {fileID: 21300000, guid: c8f8fe1d78170e84eab15e7562604fdc, type: 3}
   descripcion: 
-  costoMana: 10
-  prefabUnidad: {fileID: 0}
+  costoMana: 1
+  prefabUnidad: {fileID: 4836280685690848794, guid: 4230330b751b2b143895cfdbbef3e622, type: 3}

--- a/Assets/Scripts/CardPlayController.cs
+++ b/Assets/Scripts/CardPlayController.cs
@@ -1,0 +1,76 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class CardPlayController : MonoBehaviour
+{
+    public static CardPlayController Instance;
+
+    [Header("Configuración")]
+    public LayerMask groundLayer; // Capa del suelo (Floor) para saber dónde spawnear
+
+    private CardData currentCardData;   // Datos de la carta que estamos arrastrando
+    private CardDisplay currentCardUI;  // Referencia visual para destruirla/reciclarla luego
+
+    private void Awake()
+    {
+        if (Instance == null) Instance = this;
+    }
+
+    // 1. Empieza el arrastre: Guardamos qué carta es
+    public void StartDrag(CardData data, CardDisplay ui)
+    {
+        currentCardData = data;
+        currentCardUI = ui;
+    }
+
+    // 2. Termina el arrastre: Intentamos poner la tropa
+    public void EndDrag()
+    {
+        if (currentCardData == null) return;
+
+        // Lanzar rayo desde la cámara a la posición del mouse
+        Ray ray = Camera.main.ScreenPointToRay(Input.mousePosition);
+        RaycastHit hit;
+
+        // Verificamos si el rayo chocó con el suelo (Layer Ground)
+        if (Physics.Raycast(ray, out hit, 1000f, groundLayer))
+        {
+            // Validar si hay maná suficiente
+            if (ManaManager.Instance.TrySpendMana(currentCardData.costoMana))
+            {
+                SpawnUnit(hit.point);
+
+                // Opcional: Avisar al DeckManager que la carta se usó (para borrarla de la mano)
+                // DeckManager.Instance.DiscardCard(currentCardUI); 
+                // Por ahora solo la destruimos visualmente para probar:
+                Destroy(currentCardUI.gameObject);
+            }
+            else
+            {
+                Debug.Log("¡No hay suficiente maná!");
+            }
+        }
+        else
+        {
+            Debug.Log("Posición inválida (No soltaste la carta en el suelo)");
+        }
+
+        // Limpiar referencias
+        currentCardData = null;
+        currentCardUI = null;
+    }
+
+    void SpawnUnit(Vector3 position)
+    {
+        if (currentCardData.prefabUnidad != null)
+        {
+            Instantiate(currentCardData.prefabUnidad, position, Quaternion.identity);
+            Debug.Log($"Unidad invocada: {currentCardData.nombreCarta}");
+        }
+        else
+        {
+            Debug.LogError("¡La carta no tiene Prefab asignado en el ScriptableObject!");
+        }
+    }
+}

--- a/Assets/Scripts/CardPlayController.cs.meta
+++ b/Assets/Scripts/CardPlayController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 990b268e422acdb4488e71ee9c971a8f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -17,7 +17,7 @@ TagManager:
   - Troop
   - Building
   - Projectile
-  - 
+  - Ground
   - 
   - 
   - 


### PR DESCRIPTION
Título: Feature/Mecánica: Drag & Drop y Despliegue de Unidades

Resumen del Cambio Se implementó la interacción principal del juego: la capacidad de arrastrar una carta desde la mano y soltarla en la arena para invocar una unidad. Este PR conecta el sistema de Input con el ManaManager y la lógica de instanciación en la arena.

Archivos Principales

CardPlayController.cs (Nuevo): Script central (Singleton). Gestiona el Raycast desde la cámara, detecta el suelo válido y ordena el spawn de la unidad.

CardDisplay.cs (Modificado): Se agregaron las interfaces IDragHandler, IBeginDrag y IEndDrag para permitir el arrastre visual.

CardData.cs (Nuevo): ScriptableObject para definir los datos de cada carta (Costo, Prefab, Icono).

Objeto PlayerSpawnZone: Se creó un colisionador invisible con el Layer "Ground" que delimita la zona permitida para jugar cartas (solo la mitad del jugador).

Criterios de Aceptación (QA)

✅ Arrastrar y Soltar: Las cartas siguen al puntero del mouse/dedo al arrastrarlas.

✅ Gasto de Maná: Al soltar la carta, se verifica y consume el maná correctamente (ManaManager.Instance.TrySpendMana).

✅ Spawn: La unidad aparece en la posición exacta del impacto del Raycast.

✅ Restricción de Zona:

Se eliminó el layer "Ground" del piso general.

Solo se permite invocar sobre la PlayerSpawnZone (mitad aliada).

Si se suelta fuera de zona o sin maná, la carta regresa a la mano y no se invoca nada.

Notas Técnicas Se utiliza Physics.Raycast filtrando por una LayerMask específica ("Ground") para asegurar que las unidades no se puedan colocar encima de obstáculos o en el vacío.