### PR TITLE
Implementar networking 1v1 y conexión probada

### DIFF
--- a/Assets/DefaultNetworkPrefabs.asset
+++ b/Assets/DefaultNetworkPrefabs.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e651dbb3fbac04af2b8f5abf007ddc23, type: 3}
+  m_Name: DefaultNetworkPrefabs
+  m_EditorClassIdentifier: 
+  IsDefault: 1
+  List: []

--- a/Assets/DefaultNetworkPrefabs.asset.meta
+++ b/Assets/DefaultNetworkPrefabs.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ff78393968567e048b995e472bfe2304
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Networking.meta
+++ b/Assets/Scripts/Networking.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 67d8ca06ba3d0ec4da85f89163f059cf
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Networking/NetworkManagerController.cs
+++ b/Assets/Scripts/Networking/NetworkManagerController.cs
@@ -1,0 +1,17 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using Unity.Netcode;
+
+public class NetworkManagerController : MonoBehaviour
+{
+    public void StartHost()
+    {
+        NetworkManager.Singleton.StartHost();
+    }
+
+    public void StartClient()
+    {
+        NetworkManager.Singleton.StartClient();
+    }
+}

--- a/Assets/Scripts/Networking/NetworkManagerController.cs.meta
+++ b/Assets/Scripts/Networking/NetworkManagerController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ba2bd29656f36434c89d94c593ed2a9a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -10,6 +10,7 @@
     "com.unity.ide.rider": "3.0.36",
     "com.unity.ide.visualstudio": "2.0.22",
     "com.unity.ide.vscode": "1.2.5",
+    "com.unity.netcode.gameobjects": "1.12.2",
     "com.unity.purchasing": "4.11.0",
     "com.unity.test-framework": "1.1.33",
     "com.unity.textmeshpro": "3.0.7",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -43,11 +43,31 @@
       },
       "url": "https://packages.unity.com"
     },
+    "com.unity.burst": {
+      "version": "1.8.21",
+      "depth": 2,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.mathematics": "1.2.1",
+        "com.unity.modules.jsonserialize": "1.0.0"
+      },
+      "url": "https://packages.unity.com"
+    },
     "com.unity.collab-proxy": {
       "version": "2.10.2",
       "depth": 0,
       "source": "registry",
       "dependencies": {},
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.collections": {
+      "version": "1.2.4",
+      "depth": 2,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.burst": "1.6.6",
+        "com.unity.test-framework": "1.1.31"
+      },
       "url": "https://packages.unity.com"
     },
     "com.unity.editorcoroutines": {
@@ -99,6 +119,30 @@
     "com.unity.ide.vscode": {
       "version": "1.2.5",
       "depth": 0,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.mathematics": {
+      "version": "1.2.6",
+      "depth": 2,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.netcode.gameobjects": {
+      "version": "1.12.2",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.transport": "1.4.0",
+        "com.unity.nuget.mono-cecil": "1.10.1"
+      },
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.nuget.mono-cecil": {
+      "version": "1.11.4",
+      "depth": 1,
       "source": "registry",
       "dependencies": {},
       "url": "https://packages.unity.com"
@@ -198,6 +242,17 @@
         "com.unity.modules.director": "1.0.0",
         "com.unity.modules.animation": "1.0.0",
         "com.unity.modules.particlesystem": "1.0.0"
+      },
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.transport": {
+      "version": "1.5.0",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.burst": "1.6.6",
+        "com.unity.collections": "1.2.4",
+        "com.unity.mathematics": "1.2.6"
       },
       "url": "https://packages.unity.com"
     },


### PR DESCRIPTION
Descripción del PR

Implementar la tecnología base para habilitar la conexión 1v1 entre dos jugadores en la partida.

📝 Detalles de Implementación Técnica:

- Archivo clave: **NetworkManagerController.cs**
Maneja la inicialización de la red, el Host y el Client.

- Se utilizó **Netcode** for GameObjects como tecnología de red.
Justificación: Permite sincronización de GameObjects y escalabilidad para futuras partidas multijugador.

- Lógica implementada:
StartHost() para levantar el Host.
StartClient() para conectarse al Host.

✅ Criterios de Aceptación Verificados

- La solución de red está inicializada y configurada correctamente.

- Dos instancias del juego (Editor ↔ Build) se conectan exitosamente a la misma “room”.

- Prueba de conexión realizada con logs:
<img width="443" height="205" alt="Captura de pantalla 2025-12-05 034759" src="https://github.com/user-attachments/assets/bda1e104-dba4-467b-9f4a-4321233464bd" />
