### PR TITLE
Se implemento la logica para host y cliente de victoria y derrota

### DIFF
--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -1,0 +1,181 @@
+using System.Collections.Generic;
+using UnityEngine;
+using Unity.Netcode;
+using TMPro;
+
+public class GameManager : NetworkBehaviour
+{
+    public static GameManager Instance;
+
+    [Header("Configuración")]
+    [SerializeField] private float partidaDuracion = 90f; // 1:30 minutos
+
+    [Header("Referencias de Torres")]
+    public Health redKingTower;
+    public List<Health> redPrincessTowers;
+    public Health blueKingTower;
+    public List<Health> bluePrincessTowers;
+
+    [Header("Interfaz (UI)")]
+    public TextMeshProUGUI timerText;
+    public GameObject winPanel;
+    public TextMeshProUGUI winnerText;
+
+    // YA NO NECESITAMOS EL BOTÓN
+    // public Button startButton; 
+
+    // Variables de Red
+    private NetworkVariable<float> currentTimer = new NetworkVariable<float>(90f);
+    private NetworkVariable<bool> isGameOver = new NetworkVariable<bool>(false);
+    private NetworkVariable<bool> isMatchActive = new NetworkVariable<bool>(false);
+    // --- AGREGA ESTA LÍNEA ---
+    // Esto permite que otros scripts pregunten "¿Ya empezamos?"
+    public bool IsMatchActive => isMatchActive.Value;
+    // --------------------------
+
+    private void Awake()
+    {
+        if (Instance == null) Instance = this;
+    }
+
+    private void Start()
+    {
+        if (winPanel != null) winPanel.SetActive(false);
+    }
+
+    public override void OnNetworkSpawn()
+    {
+        if (IsServer)
+        {
+            currentTimer.Value = partidaDuracion;
+
+            // SUSCRIBIRSE AL EVENTO DE CONEXIÓN
+            // Esto le dice al servidor: "Avísame cuando alguien se conecte"
+            NetworkManager.Singleton.OnClientConnectedCallback += CheckPlayersCount;
+        }
+    }
+
+    public override void OnNetworkDespawn()
+    {
+        // Limpieza: Nos desuscribimos para evitar errores al salir
+        if (IsServer && NetworkManager.Singleton != null)
+        {
+            NetworkManager.Singleton.OnClientConnectedCallback -= CheckPlayersCount;
+        }
+    }
+
+    // Esta función se ejecuta automáticamente cada vez que alguien entra
+    private void CheckPlayersCount(ulong clientId)
+    {
+        if (!IsServer) return;
+
+        // Contamos cuántos jugadores hay conectados
+        // El Host cuenta como 1. Cuando entra el Cliente, serán 2.
+        int connectedPlayers = NetworkManager.Singleton.ConnectedClients.Count;
+
+        if (connectedPlayers >= 2)
+        {
+            StartMatch();
+        }
+    }
+
+    private void StartMatch()
+    {
+        // Solo iniciamos si no ha empezado ya
+        if (!isMatchActive.Value)
+        {
+            Debug.Log("¡JUGADOR 2 CONECTADO! INICIANDO PARTIDA...");
+            isMatchActive.Value = true; // Esto activa el reloj para todos
+        }
+    }
+
+    private void Update()
+    {
+        UpdateTimerUI();
+
+        // Lógica del Servidor
+        if (IsServer)
+        {
+            // SI NO HAY 2 JUGADORES, EL TIEMPO NO CORRE
+            if (!isMatchActive.Value || isGameOver.Value) return;
+
+            // 1. Restar Tiempo
+            currentTimer.Value -= Time.deltaTime;
+
+            // 2. Chequear Torre del Rey (Victoria Instantánea)
+            if (!redKingTower.IsAlive) { EndGame("¡GANA EL EQUIPO AZUL!"); return; }
+            if (!blueKingTower.IsAlive) { EndGame("¡GANA EL EQUIPO ROJO!"); return; }
+
+            // 3. Chequear Tiempo Agotado
+            if (currentTimer.Value <= 0f)
+            {
+                CheckTimeOutWinner();
+            }
+        }
+    }
+
+    // --- (Resto de funciones de victoria IGUALES) ---
+
+    private void CheckTimeOutWinner()
+    {
+        int redDestroyed = CountDeadTowers(redPrincessTowers);
+        int blueDestroyed = CountDeadTowers(bluePrincessTowers);
+
+        if (blueDestroyed > redDestroyed) EndGame("¡GANA EL EQUIPO ROJO!");
+        else if (redDestroyed > blueDestroyed) EndGame("¡GANA EL EQUIPO AZUL!");
+        else CheckTieBreaker();
+    }
+
+    private int CountDeadTowers(List<Health> towers)
+    {
+        int count = 0;
+        foreach (var t in towers) if (!t.IsAlive) count++;
+        return count;
+    }
+
+    private void CheckTieBreaker()
+    {
+        if (redKingTower.CurrentHealth.Value > blueKingTower.CurrentHealth.Value) EndGame("¡GANA EL ROJO!");
+        else if (blueKingTower.CurrentHealth.Value > redKingTower.CurrentHealth.Value) EndGame("¡GANA EL AZUL!");
+        else EndGame("¡EMPATE!");
+    }
+
+    private void EndGame(string winnerMessage)
+    {
+        isGameOver.Value = true;
+        ShowWinPanelClientRpc(winnerMessage);
+    }
+
+    [ClientRpc]
+    private void ShowWinPanelClientRpc(string message)
+    {
+        if (winPanel != null)
+        {
+            winPanel.SetActive(true);
+            if (winnerText != null) winnerText.text = message;
+        }
+    }
+
+    private void UpdateTimerUI()
+    {
+        if (timerText != null)
+        {
+            float t = Mathf.Max(0, currentTimer.Value);
+            int m = Mathf.FloorToInt(t / 60);
+            int s = Mathf.FloorToInt(t % 60);
+            timerText.text = string.Format("{0:00}:{1:00}", m, s);
+
+            // Feedback visual: Si la partida no ha empezado, mostramos texto de espera
+            if (!isMatchActive.Value && !isGameOver.Value)
+            {
+                // Opcional: Puedes cambiar el color a amarillo mientras espera
+                timerText.color = Color.yellow;
+            }
+            else
+            {
+                if (t < 10) timerText.color = Color.red;
+                else timerText.color = Color.white;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/GameManager.cs.meta
+++ b/Assets/Scripts/GameManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e655f52d868343a488c11c96b08f1adb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Título del PR: Feat/game-loop-completion: Lógica de Victoria/Derrota, Temporizador y Flujo de Fin de Partida

Descripción General: Este PR completa el ciclo de juego (Game Loop) implementando las condiciones de victoria y derrota para Host y Cliente. Se añade un GameManager autoritativo que sincroniza el tiempo de la partida y decide el ganador basado en reglas estilo Clash Royale (Muerte súbita o conteo de torres). También se añade la funcionalidad para desconectarse y volver al menú principal al finalizar la partida.

Cambios Técnicos Realizados:

GameManager.cs (Actualizado):

Se implementó la detección automática de inicio: La partida comienza y el maná/tiempo corren solo cuando hay 2 jugadores conectados.

Sincronización de Tiempo: Se añadió currentTimer como NetworkVariable para mantener el reloj sincronizado (90s).

Lógica de Victoria Instantánea: Si una Torre del Rey (King Tower) muere, el juego termina inmediatamente.

Lógica de Tiempo Agotado: Si el reloj llega a 0, se calculan las torres destruidas de cada equipo para decidir el ganador.

Desempate: En caso de empate en torres, gana quien tenga más vida en su Torre del Rey.

UI RPC: Se implementó ShowWinPanelClientRpc para mostrar el panel de victoria en ambas pantallas simultáneamente.

ReturnToMenu.cs (Nuevo Script):

Maneja la desconexión limpia de Unity Netcode (Shutdown) y la destrucción del NetworkManager.

Carga la escena MenuPrincipal para permitir jugar una nueva partida sin errores.

Integración de UI:

Conexión del texto del temporizador y el panel de "Game Over".

Configuración del botón "Volver al Menú" en la escena de la Arena.

Cómo Probar (QA):

Inicio Automático: Conectar Host y Cliente. Verificar que el reloj y la regeneración de maná comiencen solo cuando ambos están en la Arena.

Victoria por Rey: Destruir la torre central enemiga. Verificar que aparezca el cartel de victoria inmediatamente.

Victoria por Tiempo: Esperar a que el reloj llegue a 00:00. Verificar que gane quien haya destruido más torres pequeñas.

Reinicio: Al terminar la partida, pulsar "Volver al Menú". Verificar que se carga el menú principal y se puede crear/unir a una nueva partida correctamente.

⚠️ Notas de Configuración (Inspector):

Asegurarse de que el objeto GameManager en la escena Arena tenga asignadas todas las referencias de las torres (Health scripts) en las listas correspondientes (Red/Blue).

El botón del WinPanel debe tener asignado el evento ReturnToMenu.VolverAlMenu.